### PR TITLE
Remove options from createuser command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install required Python packages
 Create the database
 
 ```
-sudo -u postgres createuser -L -R -S digihel
+sudo -u postgres createuser digihel
 sudo -u postgres createdb -O digihel digihel
 ```
 


### PR DESCRIPTION
These options (NOLOGIN) do not really make sense when installing a single application that will use its own database alone.