### PR TITLE
Fix CI oddities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,3 @@ notifications:
 cache:
   directories:
     - /home/travis/.cache/pip
-    - /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages


### PR DESCRIPTION
* Don't cache site-packages directory - This occasionally causes py.test entry point conflicts in Travis.