### PR TITLE
Make blog templates support multiple blogs. 

### DIFF
--- a/digi/models.py
+++ b/digi/models.py
@@ -1,4 +1,4 @@
-from blog.models import BlogCategory, BlogPage
+from blog.models import BlogCategory, BlogPage, BlogIndexPage
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from modelcluster.fields import ParentalKey
@@ -81,7 +81,7 @@ class GuideFrontPage(RelativeURLMixin, Page):
 
     @property
     def blog_posts(self):
-        posts = BlogPage.objects.all().live().filter(tags__name='digipalveluopas').order_by('-date')
+        posts = BlogPage.objects.descendant_of(self).live().order_by('-date')
         return posts
 
 class GuideContentPage(RelativeURLMixin, Page):
@@ -203,7 +203,8 @@ class FrontPage(RelativeURLMixin, Page):
 
     @property
     def blog_posts(self):
-        posts = BlogPage.objects.all().live().order_by('-date')
+        main_blog_index = BlogIndexPage.objects.get(slug="blogikirjoitukset")
+        posts = BlogPage.objects.descendant_of(main_blog_index).live().order_by('-date')
         return posts
 
     @property

--- a/digi/templates/blog/blog_index_page.html
+++ b/digi/templates/blog/blog_index_page.html
@@ -13,7 +13,7 @@
       {% else %}
       <div class="row">
         <div class="col-xs-12">
-          <h2 class="blog-section-header"><a href="/blogikirjoitukset">Blogi</a></h2>
+          <h2 class="blog-section-header"><a href="{{ self.url }}">{{self.title}}</a></h2>
         </div>
         {% for blog in blogs|slice:":1" %}
         <div class="col-xs-12">

--- a/digi/templates/blog/blog_post.html
+++ b/digi/templates/blog/blog_post.html
@@ -7,7 +7,7 @@
 <div class="container main-container page-content blog-post-container" role="main">
     <div class="row">
     <div class="col-xs-12">
-        <h2 class="blog-section-header"><a href="/blogikirjoitukset">Blogi</a></h2>
+        <h2 class="blog-section-header"><a href="{{ self.get_blog_index.url }}">{{self.get_blog_index.title}}</a></h2>
     </div>
   <div class="page-header-blogpost col-xs-12 col-sm-10">
 {% endif %}

--- a/digi/templates/digi/guide_front_page.html
+++ b/digi/templates/digi/guide_front_page.html
@@ -77,10 +77,12 @@
           </div>
       </section>
 
-      <h2>Tarinoita digipajalta</h2>
+      {% if  self.blog_posts %}
+
+      <h2>Digitarinoita</h2>
 
       <ul class="blog-index list-unstyled the-loop row">
-            {% for blog in page.blog_posts|slice:":2" %}
+            {% for blog in self.blog_posts|slice:":2" %}
             <li class="blog-post-item first-reset match-height" style="height: 560px;">
               <div class="blog-post-preview">
                 <div class="blog-post-header">
@@ -100,6 +102,10 @@
             </div></li>
             {% endfor %}
         </ul>
-      <p class="text-center"><a href="/blogikirjoitukset" class="btn btn-default">Lisää tarinoita blogissa</a></p>
+        {% if self.blog_posts|length > 2 %}
+        <p class="text-center"><a href="tarinat/" class="btn btn-default">Kaikki digitarinat</a></p>
+        {% endif %}
+
+      {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Show related blog content on front page and digiguide font page.

In the future latest blog posts list could be a custom template tag. But this solution should do for now.