### PR TITLE
Fix IE svg spacing bug

### DIFF
--- a/digihel/static/css/digihel.scss
+++ b/digihel/static/css/digihel.scss
@@ -1489,6 +1489,9 @@ $labelheight:     22px;
     width: 5.5em;
     padding: $line-height-computed/2;
     vertical-align: middle;
+    img {
+      height: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes extra spacing appearing on svg images on certain IE11 versions.