### PR TITLE
Make feedback compatible with DRF >3.3.0

### DIFF
--- a/feedback/views.py
+++ b/feedback/views.py
@@ -10,6 +10,7 @@ from .models import Feedback
 class FeedbackSerializer(serializers.ModelSerializer):
     class Meta:
         model = Feedback
+        fields = '__all__'
 
 
 @method_decorator(csrf_exempt, name='dispatch')


### PR DESCRIPTION
> Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = '__all__' to the FeedbackSerializer serializer.