### PR TITLE
Fixes for case filter form

### DIFF
--- a/helsinkioppii/forms.py
+++ b/helsinkioppii/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 from taggit.models import Tag
 
-from helsinkioppii.models.cases import Case, SchoolGrade, SchoolSubject
+from helsinkioppii.models.cases import Case, SchoolGrade, SchoolSubject, CaseTheme
 
 
 def get_live_case_keywords():
@@ -26,11 +26,11 @@ class CaseFilterForm(forms.Form):
             'placeholder': _('Search'),
         }),
     )
-    keywords = forms.ModelMultipleChoiceField(
-        get_live_case_keywords(),
-        label=_('Keywords'),
+    themes = forms.ModelMultipleChoiceField(
+        CaseTheme.objects.all(),
+        label=_('Themes'),
         widget=forms.CheckboxSelectMultiple(attrs={
-            'class': 'list-unstyled checkbox'
+            'class': 'filter-keywordlist list-unstyled checkbox'
         }),
         required=False,
     )
@@ -38,7 +38,7 @@ class CaseFilterForm(forms.Form):
         SchoolGrade.objects.all(),
         label=_('School grades'),
         widget=forms.CheckboxSelectMultiple(attrs={
-            'class': 'list-unstyled checkbox'
+            'class': 'filter-keywordlist list-unstyled checkbox'
         }),
         required=False,
     )
@@ -46,7 +46,7 @@ class CaseFilterForm(forms.Form):
         SchoolSubject.objects.all(),
         label=_('School subjects'),
         widget=forms.CheckboxSelectMultiple(attrs={
-            'class': 'list-unstyled checkbox'
+            'class': 'filter-keywordlist list-unstyled checkbox'
         }),
         required=False,
     )

--- a/helsinkioppii/models/pages.py
+++ b/helsinkioppii/models/pages.py
@@ -128,7 +128,7 @@ class CaseListPage(Page):
 
         if form.is_valid():
             free_text = form.cleaned_data.get('free_text')
-            keywords = form.cleaned_data.get('keywords')
+            themes = form.cleaned_data.get('themes')
             grades = form.cleaned_data.get('grades')
             subjects = form.cleaned_data.get('subjects')
 
@@ -137,8 +137,8 @@ class CaseListPage(Page):
                 q_abstract = Q(abstract__icontains=free_text)
                 q_content = Q(content__icontains=free_text)
                 cases = cases.filter(q_title | q_abstract | q_content)
-            if keywords:
-                cases = cases.filter(keywords__in=keywords)
+            if themes:
+                cases = cases.filter(theme__in=themes)
             if grades:
                 cases = cases.filter(grade__in=grades)
             if subjects:

--- a/helsinkioppii/static/css/digiedu.scss
+++ b/helsinkioppii/static/css/digiedu.scss
@@ -105,6 +105,23 @@ $icon-font-path: '../bootstrap-sass/assets/fonts/bootstrap/';
   padding: $line-height-computed * 2 0;
 }
 
+.filter-field {
+  margin-bottom: $line-height-computed;
+  .form-control {
+    &::placeholder {
+      color: rgba(#000000, .33);
+    }
+  }
+}
+
+.filter-keywordlist {
+  display: block;
+  overflow-y: scroll;
+  max-height: $line-height-computed * 6;
+  padding: $line-height-computed / 2;
+  border: 2px solid $black;
+}
+
 .section--cases-list {
   padding-top: $line-height-computed * 3;
   background-color: $hel-silver;

--- a/helsinkioppii/templates/helsinkioppii/blocks/banner_lift.html
+++ b/helsinkioppii/templates/helsinkioppii/blocks/banner_lift.html
@@ -5,13 +5,13 @@
         {% if block.icon %}
         <figure class="banner-illustration">
             {% image block.icon fill-500x500 as banner_image %}
-            <a href="{{ block.page.url }}"><img src="{{ banner_image.url }}" alt="" class="illustration"></a>
+            <a href="{{ block_link_url }}"><img src="{{ banner_image.url }}" alt="" class="illustration"></a>
         </figure>
         {% endif %}
-        <h3><a href="{{ block.page.url }}">{{ block.title }}</a></h3>
+        <h3><a href="{{ block_link_url }}">{{ block.title }}</a></h3>
         <p>{{ block.abstract|truncatechars:225 }}</p>
         <p>
-            <a class="btn btn-default" href="{{ block.page.url }}">{% trans "Read more" %}</a>
+            <a class="btn btn-default" href="{{ block_link_url }}">{% trans "Read more" %}</a>
         </p>
     </div>
 </div>

--- a/helsinkioppii/templates/helsinkioppii/case_list_page.html
+++ b/helsinkioppii/templates/helsinkioppii/case_list_page.html
@@ -10,7 +10,7 @@
             <form action="{{ page.url }}" method="get">
                 <div class="row">
                     {% for field in form.visible_fields %}
-                        <div class="col-md-3 col-sm-6">
+                        <div class="filter-field col-md-3 col-sm-6">
                             {{ field.errors }}
                             <label for="{{ field.id_for_label }}">
                                 {{ field.label }}
@@ -24,7 +24,7 @@
                         </div>
                     {% endfor %}
                 </div>
-                <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
+                <div class="text-center"><button type="submit" class="btn btn-primary">{% trans "Search" %}</button></div>
             </form>
         </div>
     </section>

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-13 09:46+0200\n"
+"POT-Creation-Date: 2017-11-15 10:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -133,8 +133,8 @@ msgid "Search"
 msgstr "Etsi"
 
 #: helsinkioppii/forms.py:31
-msgid "Keywords"
-msgstr "Avainsanat"
+msgid "Themes"
+msgstr "Teemat"
 
 #: helsinkioppii/forms.py:39
 msgid "School grades"
@@ -220,9 +220,9 @@ msgstr "training-osion otsikko"
 msgid "training section description"
 msgstr "training-osion kuvais"
 
-#: helsinkioppii/templates/helsinkioppii/blocks/banner_lift.html:11
-#: helsinkioppii/templates/helsinkioppii/blocks/case_lift.html:13
-#: helsinkioppii/templates/helsinkioppii/blocks/training_lift.html:8
+#: helsinkioppii/templates/helsinkioppii/blocks/banner_lift.html:14
+#: helsinkioppii/templates/helsinkioppii/blocks/case_lift.html:16
+#: helsinkioppii/templates/helsinkioppii/blocks/training_lift.html:9
 msgid "Read more"
 msgstr "Lue lisää"
 
@@ -273,3 +273,6 @@ msgstr "Sivun lisäasetukset"
 #: people/wagtail_hooks.py:9
 msgid "People"
 msgstr "Henkilöt"
+
+#~ msgid "Keywords"
+#~ msgstr "Avainsanat"


### PR DESCRIPTION
- Use `theme` field as filter instead of `keywords`.
- Make long filter checkbox lists look prettier