### PR TITLE
Helsinkioppii: Fix index hero image height

### DIFF
--- a/helsinkioppii/static/css/digiedu.scss
+++ b/helsinkioppii/static/css/digiedu.scss
@@ -42,33 +42,8 @@ $icon-font-path: '../bootstrap-sass/assets/fonts/bootstrap/';
   background-color: $gray-lighter;
 
   &.index {
-    min-height: 1050px;
-
     .hero-content {
-      padding-top: 320px;
-      color: $white;
-      font-size: 44px;
-      font-weight: bold;
-      min-height: $line-height-computed * 20;
-      position: relative;
-      text-shadow: 1px 1px 4px rgba(#000, 0.2);
-    }
-  }
-
-  .index-hero-koro__bottom {
-    @include koro("pulse", #ffffff, 600);
-    background-color: transparent;
-    width: 100%;
-    height: $line-height-computed * 3;
-    position: absolute;
-    bottom: 0;
-  }
-
-  &.index {
-    min-height: 1050px;
-
-    .hero-content {
-      padding-top: 320px;
+      padding-top: 160px;
       color: $white;
       font-size: 44px;
       font-weight: bold;
@@ -428,6 +403,7 @@ ul.reference-list {
 
 .section--training-hero {
   height: $line-height-computed * 16;
+
   .hero-content {
     padding: $line-height-computed * 2;
     text-align: center;


### PR DESCRIPTION
The hero image was too high. Revert to original height and reduce
the hero content top padding.

The index hero styles were duplicated in a merge conflict somewhere
along the line. Remove duplicate styles and add one newline further
down the file to keep code style consistent.