### PR TITLE
Fix dumb error in case create_view

### DIFF
--- a/helsinkioppii/models/pages.py
+++ b/helsinkioppii/models/pages.py
@@ -279,9 +279,9 @@ class CaseListPage(RoutablePageMixin, TranslatablePageMixin, Page):
                 self.add_child(instance=case)
 
                 # Create related objects from form data.
-                self.update_gallery_images_from_form_data(form)
-                self.update_attachments_from_form_data(form)
-                self.update_sidebar_links_from_form_data(form)
+                case.update_gallery_images_from_form_data(form)
+                case.update_attachments_from_form_data(form)
+                case.update_sidebar_links_from_form_data(form)
 
                 return redirect(case.get_url())
 


### PR DESCRIPTION
The called functions exists under the Case class and not
CaseListPage class. Replace the `self` reference with correct
`case` reference.