### PR TITLE
Fix localization issues

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -128,7 +128,7 @@ msgstr "Selain"
 
 #: helsinkioppii/blocks/banner_lift.py:12
 msgid "Overrides page link if set."
-msgstr "Yliajaa sivulinkin, jos määritetty"
+msgstr "Yliajaa sivulinkin, jos määritetty."
 
 #: helsinkioppii/fields.py:27
 #, python-format
@@ -152,7 +152,7 @@ msgstr "%s liite:"
 #: helsinkioppii/fields.py:53
 #, python-format
 msgid "%s attachment title:"
-msgstr "%s liitteen nimi"
+msgstr "%s liitteen nimi:"
 
 #: helsinkioppii/fields.py:59
 msgid "Please remember to name your attachment."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -192,11 +192,11 @@ msgstr "Utbildningsstadier"
 
 #: helsinkioppii/forms.py:55 helsinkioppii/models/cases.py:276
 msgid "School subjects"
-msgstr "Läroamnen"
+msgstr "Läroämnen"
 
 #: helsinkioppii/forms.py:75
 msgid "Title:"
-msgstr "Rubrik"
+msgstr "Rubrik:"
 
 #: helsinkioppii/forms.py:85
 msgid "Image:"
@@ -236,7 +236,7 @@ msgstr "Välj alla lämpliga läroämnen."
 
 #: helsinkioppii/forms.py:135
 msgid "Keywords:"
-msgstr "Nyckelord"
+msgstr "Nyckelord:"
 
 #: helsinkioppii/forms.py:141
 msgid "Separate multiple keywords with \";\"."


### PR DESCRIPTION
Fix typo in swedish translation. Add missing dots and colons
to couple translations that were missing them.