### PR TITLE
Use correct pytest-cov version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - nvm install 4.5.0
   - node -v
   - pip install -U pip
-  - pip install pytest-cov -r requirements.txt
+  - pip install pytest-cov==2.5.1 -r requirements.txt
   - npm install -g coffee-script
   - npm install
   - python manage.py collectstatic <<<yes


### PR DESCRIPTION
The latest pytest-cov is not compatible with current pytest version.