### PR TITLE
Improve the footer section

### DIFF
--- a/digihel/static/css/_common-styles.scss
+++ b/digihel/static/css/_common-styles.scss
@@ -1252,18 +1252,6 @@ $labelheight:     22px;
     }
   }
 
-  .footer-partners {
-    list-style: none;
-    padding-left: 0;
-    li {
-      vertical-align: top;
-      display: inline-block;
-      @media (max-width: $screen-xs-max) {
-        display: block;
-      }
-    }
-  }
-
   .partner-logo {
     margin: 1em 0 2em 2em;
     width: 5em;
@@ -1288,10 +1276,6 @@ $labelheight:     22px;
     max-width: 8em;
   }
 
-  .footer-logo-heldev {
-    max-width: 4em;
-  }
-
   a {
     color: $white;
     display: block;
@@ -1301,11 +1285,6 @@ $labelheight:     22px;
       color: $white;
       text-decoration: none;
     }
-  }
-
-  .footer-branding-text {
-    @extend small;
-    margin-bottom: 1.5em;
   }
 }
 

--- a/digihel/templates/base.html
+++ b/digihel/templates/base.html
@@ -72,7 +72,7 @@
                         <div class="page-footer-small-print">
                             <ul class="small-print-nav">
                                 <li><a href="/yhteystiedot/">Ota yhteyttä</a></li>
-                                <li>2017 Helsingin kaupunki</li>
+                                <li>{% now "Y" %} Helsingin kaupunki</li>
                             </ul>
                         </div>
                     </div>

--- a/digihel/templates/base.html
+++ b/digihel/templates/base.html
@@ -65,35 +65,11 @@
                                 <img alt="Helsingin tunnus" src="{% static "hel-bootstrap-3/src/assets/helsinki-logo-white.svg" %}" class="footer-logo footer-logo-helsinki" aria-hidden="true">
                             </a>
                         </div>
-                        <div class="footer-branding footer-branding-heldev">
-                            <a href="http://dev.hel.fi">
-                                <img alt="Helsinki loves developers" src="{% static "images/heldev_logo-white-mini.svg" %}" class="footer-logo footer-logo-heldev" aria-hidden="true">
-                                <div class="footer-branding-text">Helsingin kaupungin avoin ohjelmistokehitys</div>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="col-md-3 col-md-push-3 col-sm-4">
-                        <div class="page-footer-block">
-                            <div class="footer-header">Katso myös</div>
-                            <ul class="footer-links">
-                                <li></li>
-                                <li><a href="http://www.slideshare.net/DigitalHelsinki"><span class="icon icon-linkedin-rect"></span> Slideshare</a></li>
-                                <li><a href="https://github.com/City-of-Helsinki"><span class="icon icon-github"></span> GitHub</a></li>
-                                <li><a href="https://twitter.com/search?q=%23digihelsinki"><span class="icon icon-twitter-bird"></span> #digihelsinki</a></li>
-                            </ul>
-                        </div>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-xs-12">
                         <div class="page-footer-small-print">
-                            <div class="footer-header">Yhteistyössä</div>
-                            <ul class="footer-partners">
-                                <li><a href="http://hri.fi"><img alt="Helsinki Region Infoshare" src="{% static "images/hri_logo_darkBG.svg" %}" class="partner-logo" aria-hidden="true"></a></li>
-                                <li><a href="http://6aika.fi"><img alt="6Aika" src="{% static "images/6aika-white.svg" %}" class="partner-logo" aria-hidden="true"></a></li>
-                                <li><img alt="Vipuvoimaa EU:lta 2014—2020" src="{% static "images/eu-vipuvoimaa-white.svg" %}" class="partner-logo" aria-hidden="true"></li>
-                                <li><img alt="Euroopan Unioni Euroopan aluekehitysrahasto Euroopan sosiaalirahasto" src="{% static "images/eu-aluekehitys-white.svg" %}" class="partner-logo" aria-hidden="true"></li>
-                            </ul>
                             <ul class="small-print-nav">
                                 <li><a href="/yhteystiedot/">Ota yhteyttä</a></li>
                                 <li>2017 Helsingin kaupunki</li>

--- a/digihel/templates/base.html
+++ b/digihel/templates/base.html
@@ -47,8 +47,8 @@
         <footer class="page-footer">
             <div class="container">
                 <div class="row">
-                    <div class="col-md-3 col-md-push-6 col-sm-4 col-sm-push-4">
                     {% for section in request.site.root_page.specific.footer_link_sections %}
+                    <div class="col-md-3 col-md-push-6 col-sm-4 col-sm-push-4">
                         <div class="page-footer-block">
                             {% if section.title %}<div class="footer-header">{{ section.title }}</div>{% endif %}
                             <ul class="footer-links">
@@ -57,9 +57,9 @@
                             {% endfor %}
                             </ul>
                         </div>
-                    {% endfor %}
                     </div>
-                    <div class="col-md-3 col-md-pull-3 col-sm-4 col-sm-pull-4">
+                    {% endfor %}
+                    <div class="col-md-3 col-md-pull-6 col-sm-4 col-sm-pull-8">
                         <div class="footer-branding footer-branding-helsinki">
                             <a href="http://www.hel.fi">
                                 <img alt="Helsingin tunnus" src="{% static "hel-bootstrap-3/src/assets/helsinki-logo-white.svg" %}" class="footer-logo footer-logo-helsinki" aria-hidden="true">

--- a/digihel/tests/test_front.py
+++ b/digihel/tests/test_front.py
@@ -6,4 +6,4 @@ def test_front_page(client, home_page):
     response = client.get('/')
     assert response.status_code == 200
     print(response.content)
-    assert 'Helsinki Region Infoshare' in str(response.content)
+    assert 'Helsingin kaupunki' in str(response.content)


### PR DESCRIPTION
- Remove old sections: "Katso myös", "Yhteistyössä" and the Helsinki Open Source
- Use current year instead of the static year string
- Add second column for the footer links

![image](https://user-images.githubusercontent.com/1843169/57776561-80835a80-7728-11e9-8680-25481a4eab1a.png)
