### PR TITLE
 Use exact version instead of latest in the migration dependencies

### DIFF
--- a/digi/migrations/0002_theme_page_add_body_and_blog_category.py
+++ b/digi/migrations/0002_theme_page_add_body_and_blog_category.py
@@ -11,7 +11,7 @@ import wagtail.wagtailcore.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blog', '__latest__'),
+        ('blog', '0005_auto_20151019_1121'),
         ('digi', '0001_initial'),
     ]
 


### PR DESCRIPTION
Changed to use the latest migration of wagtail-blog v1.6.9.

Refs
https://github.com/thelabnyc/wagtail_blog/blob/5147d8129127102009c9bd63b1886e7665f6ccfb/blog/migrations/0005_auto_20151019_1121.py