### PR TITLE
Fix the link layout in footer

### DIFF
--- a/digihel/static/css/_common-styles.scss
+++ b/digihel/static/css/_common-styles.scss
@@ -1237,7 +1237,7 @@ $labelheight:     22px;
 
   .page-footer-block {
     margin-bottom: $line-height-computed * 3;
-    @media (max-width: $screen-xs-max) {
+    @media (max-width: $screen-sm-max) {
       text-align: center;
     }
   }

--- a/digihel/templates/base.html
+++ b/digihel/templates/base.html
@@ -47,24 +47,33 @@
         <footer class="page-footer">
             <div class="container">
                 <div class="row">
-                    {% for section in request.site.root_page.specific.footer_link_sections %}
-                    <div class="col-md-3 col-md-push-6 col-sm-4 col-sm-push-4">
-                        <div class="page-footer-block">
-                            {% if section.title %}<div class="footer-header">{{ section.title }}</div>{% endif %}
-                            <ul class="footer-links">
-                            {% for link in section.links.all %}
-                                <li><a href="{{ link.url }}">{{ link.title }}</a></li>
-                            {% endfor %}
-                            </ul>
-                        </div>
-                    </div>
-                    {% endfor %}
-                    <div class="col-md-3 col-md-pull-6 col-sm-4 col-sm-pull-8">
+                    <div class="col-md-3">
                         <div class="footer-branding footer-branding-helsinki">
                             <a href="http://www.hel.fi">
                                 <img alt="Helsingin tunnus" src="{% static "hel-bootstrap-3/src/assets/helsinki-logo-white.svg" %}" class="footer-logo footer-logo-helsinki" aria-hidden="true">
                             </a>
                         </div>
+                    </div>
+                    <div class="col-md-6 col-md-push-3">
+                    {% for section in request.site.root_page.specific.footer_link_sections %}
+                        {% cycle True False as row silent %}
+                        {% if row %}
+                        <div class="row">
+                        {% endif %}
+                            <div class="col-md-6">
+                                <div class="page-footer-block">
+                                    {% if section.title %}<div class="footer-header">{{ section.title }}</div>{% endif %}
+                                    <ul class="footer-links">
+                                    {% for link in section.links.all %}
+                                        <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+                                    {% endfor %}
+                                    </ul>
+                                </div>
+                            </div>
+                        {% if not row or forloop.last %}
+                        </div>
+                        {% endif %}
+                    {% endfor %}
                     </div>
                 </div>
                 <div class="row">


### PR DESCRIPTION
The implementation didn't work as it was told on the card. The link sections should be in the two columns at the footer.

![image](https://user-images.githubusercontent.com/1843169/58477772-0a85e700-815d-11e9-879d-605948e230cb.png)
