### PR TITLE
Fix archive blog link in news

### DIFF
--- a/news/templates/news/news_index_page.html
+++ b/news/templates/news/news_index_page.html
@@ -33,6 +33,6 @@
     {% else %}
         <p>Uutisissa ei tällä hetkellä ole julkaistuja kirjoituksia</p>
     {% endif %}
-    <a href="blogikirjoitukset/" class="blogs-preview-read-all">Arkisto: Digitaalinen Helsinki -ohjelman blogi <span class="caret-right"></span></a>
+    <a href="/blogikirjoitukset/" class="blogs-preview-read-all">Arkisto: Digitaalinen Helsinki -ohjelman blogi <span class="caret-right"></span></a>
   </div>
 {% endblock %}


### PR DESCRIPTION
The link was pointed to wrong path.