### PR TITLE
Update wagtailtinymce to 4.4.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/City-of-Helsinki/django-social-widgets@master#egg=django_social_widgets
 -e git+https://github.com/City-of-Helsinki/wagtail-svgmap.git@master#egg=wagtail_svgmap
--e git+https://github.com/City-of-Helsinki/wagtailtinymce.git@extensibility#egg=wagtailtinymce==4.4.3.0
+-e git+https://github.com/City-of-Helsinki/wagtailtinymce.git@extensibility#egg=wagtailtinymce==4.4.3.1
 amqp==2.4.2               # via kombu
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest


### PR DESCRIPTION
The version 4.4.3.0 contained compatibility issue with Django > 2.1.

Requires: https://github.com/City-of-Helsinki/wagtailtinymce/pull/2