### PR TITLE
Fix the TinyMCE support on Wagtail

### DIFF
--- a/digihel/tinymce.py
+++ b/digihel/tinymce.py
@@ -82,3 +82,46 @@ class DigiHelTinyMCERichTextArea(TinyMCERichTextArea):
         args['style_formats_merge'] = True
         args['extended_valid_elements'] = 'div[class]'
         return args
+
+    @classmethod
+    def getDefaultArgs(cls):
+        args = super(DigiHelTinyMCERichTextArea, cls).getDefaultArgs()
+        args['options'] = cls.default_options
+        args['height'] = 600
+        args['style_formats'] = [
+            {'title': 'Additional info', 'block': 'section', 'classes': 'more-info', 'wrapper': 'true'},
+            {'title': 'Document link', 'inline': 'span', 'classes': 'document-link'},
+        ]
+        args['style_formats_merge'] = True
+        args['extended_valid_elements'] = 'div[class]'
+        args['plugins'] = cls.plugins
+        return args
+
+    def render_js_init(self, id_, name, value):
+        kwargs = self.kwargs.copy()
+
+        if 'buttons' in self.kwargs:
+            if self.kwargs['buttons'] is False:
+                kwargs['toolbar'] = False
+            else:
+                kwargs['toolbar'] = [
+                    ' | '.join([' '.join(groups) for groups in rows])
+                    for rows in self.kwargs['buttons']
+                ]
+
+        if 'menus' in self.kwargs:
+            if self.kwargs['menus'] is False:
+                kwargs['menubar'] = False
+            else:
+                kwargs['menubar'] = ' '.join(self.kwargs['menus'])
+
+        if 'passthru_init_keys' in self.kwargs:
+            kwargs.update(self.kwargs['passthru_init_keys'])
+
+        if 'table' in self.kwargs:
+            for key, values in self.kwargs['table'].items():
+                kwargs[f'table_{key}'] = values
+
+        kwargs.pop('menubar', None)
+
+        return "makeTinyMCEEditable({0}, {1});".format(json.dumps(id_), json.dumps(kwargs))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/City-of-Helsinki/django-social-widgets@master#egg=django_social_widgets
 -e git+https://github.com/City-of-Helsinki/wagtail-svgmap.git@master#egg=wagtail_svgmap
--e git+https://github.com/City-of-Helsinki/wagtailtinymce.git@extensibility#egg=wagtailtinymce==4.4.3.0
+-e git+https://github.com/big6media/wagtailtinymce.git@master#egg=wagtailtinymce==4.7.13.6
 amqp==2.4.2               # via kombu
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest


### PR DESCRIPTION
The old Wagtail TinyMCE caused troubles in the editing of the pages. It crashed in the links and in the images as it didn't process things in a new Wagtail way.

TinyMCE in Wagtail is not anymore activitely supported so here has been finding a new version of Wagtail TinyMCE. The TinyMCE is replaced with version who's author `big6media (This can be changed to pointing to own repositories after that is forked or branched) as it contained the latest fixes.